### PR TITLE
Adding support for ssh key authentication

### DIFF
--- a/connection/SshTarget.py
+++ b/connection/SshTarget.py
@@ -18,12 +18,13 @@ import paramiko
 
 
 class SshTarget(paramiko.client.SSHClient):
-    def __init__(self, host, name=None, wait=False, user="root", port=22, password=""):
+    def __init__(self, host, name=None, wait=False, user="root", port=22, password=None, pkey=None):
         super().__init__()
         self.user = user
         self.host = host
         self.port = port
         self.password = password
+        self.pkey = pkey
         self.name = name if name else host
         self.stdin = None
         self.stdout = None
@@ -43,7 +44,7 @@ class SshTarget(paramiko.client.SSHClient):
         while start + 10 > now:
             try:
                 self.connect(self.host, username=self.user, port=self.port, timeout=1, banner_timeout=1,
-                             auth_timeout=1, password=self.password)
+                             auth_timeout=1, password=self.password, pkey=self.pkey)
                 peer = self.get_transport().getpeername()
                 logging.info("%-13s I'm connected to %s:%d as %s" % (cmd_name, peer[0], peer[1], self.user))
                 return

--- a/connection/wfx_connection.py
+++ b/connection/wfx_connection.py
@@ -302,16 +302,16 @@ class Telnet(AbstractConnection):
 
 class Ssh(AbstractConnection):
 
-    def __init__(self, name=None, user="pi", host="10.5.124.249", port=22, password=""):
+    def __init__(self, name=None, user="pi", host="10.5.124.249", port=22, password="", pkey=None):
         self.nickname = name if name else 'ssh'
         self.conn = 'SSH ' + user + '@' + host + ':' + str(port)
         super().__init__()
         if host:
-            self.configure(user=user, host=host, port=port, password=password)
+            self.configure(user=user, host=host, port=port, password=password, pkey=pkey)
 
-    def configure(self, user="pi", host="10.5.124.249", port=22, password="default_password"):
+    def configure(self, user="pi", host="10.5.124.249", port=22, password="default_password", pkey=None):
         import SshTarget
-        self.link = SshTarget.SshTarget(user=user, host=host, name=self.nickname, port=port, password=password)
+        self.link = SshTarget.SshTarget(user=user, host=host, name=self.nickname, port=port, password=password, pkey=pkey)
 
     def write(self, text):
         if self.link is not None:

--- a/test-feature/wfx_test_target.py
+++ b/test-feature/wfx_test_target.py
@@ -49,9 +49,10 @@ class WfxTestTarget(object):
             host = kwargs['host']
             port = kwargs['port'] if 'port' in kwargs else 22
             user = kwargs['user'] if 'user' in kwargs else 'root'
+            pkey = kwargs['pkey'] if 'pkey' in kwargs else None
             print('%s: Configuring a SSH connection to host %s for user %s' % (nickname, host, user))
             password = kwargs['password'] if 'password' in kwargs else None
-            self.link = Ssh(nickname, host=host, user=user, port=port, password=password)
+            self.link = Ssh(nickname, host=host, user=user, port=port, password=password, pkey=pkey)
 
         if not self.link:
             if 'port' in kwargs:


### PR DESCRIPTION
Most embedded targets using wfx chips do not generally allow password ssh logins, working with ssh keys instead. Add support for key-based connections.