### PR TITLE
Providing a login shell in ssh connections

### DIFF
--- a/connection/SshTarget.py
+++ b/connection/SshTarget.py
@@ -87,7 +87,8 @@ class SshTarget(paramiko.client.SSHClient):
 
     def write(self, text):
         if self is not None:
-            self.stdin, self.stdout, self.stderr = self.exec_command(text, environment={'ENV': '/etc/profile'})
+            cmd = b"/bin/sh --login -c " + text  # Provide a login shell to set the environment and locate scripts
+            self.stdin, self.stdout, self.stderr = self.exec_command(cmd, environment={'ENV': '/etc/profile'})
 
     def read(self):
         self.result = str(self.stdout.read(), "utf-8").strip()

--- a/connection/wfx_connection.py
+++ b/connection/wfx_connection.py
@@ -8,6 +8,7 @@
 # Standard library imports
 import logging
 import os
+import shlex
 import sys
 import time
 
@@ -319,7 +320,7 @@ class Ssh(AbstractConnection):
                 for line in text.rstrip().split('\n'):
                     print(str.format("%-8s S>>|  " % self.nickname), end='')
                     print(line)
-            self.link.write(bytes(text.rstrip() + '\n', 'utf-8'))
+            self.link.write(bytes(shlex.quote(text).rstrip() + '\n', 'utf-8'))
 
     def read(self):
         if self.link is not None:


### PR DESCRIPTION
The `exec_command` method of the paramiko module sends a command through a non-login, non-interactive shell. Such a shell has a meager environment, since the `/etc/profile` standard file is never sourced. This generates errors in many of the `WfxTestDut` methods such as the `read_*_version` family, which calls `wfx_test_agent` without knowing where it's located. It also leaves the class user with no other option than to manually pass environment variables to the `run` method.

Ensure that a login shell is passed on every command with the properly escaped string.

Fixes https://github.com/SiliconLabs/wfx-common-tools/issues/5