### PR TITLE
Explicitly add dependencies removed in python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "paramiko>=2.7.1",
   "pyserial>=3.4",
   "ifaddr>=0.1.6",  
+  "setuptools>=80.9.0",
 ]
 
 maintainers = [


### PR DESCRIPTION
Python 3.12 has [removed
distutils](https://docs.python.org/3/whatsnew/3.12.html) from the standard library. Since this project makes use of distutils, users of Python 3.12+ will get an error when using the library. Explicitly add distutils through the `setuptools` package.